### PR TITLE
Migrated attribute modifiers to Vanilla system

### DIFF
--- a/src/main/java/net/nieadni/hyliacraft/item/HCItems.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/HCItems.java
@@ -2,6 +2,8 @@ package net.nieadni.hyliacraft.item;
 
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.item.*;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.registry.Registries;
@@ -36,11 +38,11 @@ public class HCItems extends Items {
     // Iron Bow
     // Boomerang
     // Gale Boomerang
-    public static final Item GODDESS_SWORD = register(new GoddessSwordItem(GoddessSwordMaterial.INSTANCE, new Item.Settings().attributeModifiers(GoddessSwordItem.createAttributeModifiers(GoddessSwordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.RARE)),"goddess_sword");
-    public static final Item GODDESS_LONGSWORD = register(new GoddessLongswordItem(GoddessLongswordMaterial.INSTANCE, new Item.Settings().attributeModifiers(GoddessLongswordItem.createAttributeModifiers(GoddessLongswordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.RARE)),"goddess_longsword");
-    public static final Item GODDESS_WHITE_SWORD = register(new GoddessWhiteSwordItem(GoddessWhiteSwordMaterial.INSTANCE, new Item.Settings().attributeModifiers(GoddessWhiteSwordItem.createAttributeModifiers(GoddessWhiteSwordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.RARE)),"goddess_white_sword");
-    public static final Item MASTER_SWORD = register(new MasterSwordItem(MasterSwordMaterial.INSTANCE, new Item.Settings().attributeModifiers(MasterSwordItem.createAttributeModifiers(MasterSwordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.EPIC)),"master_sword");
-    public static final Item TRUE_MASTER_SWORD = register(new TrueMasterSwordItem(TrueMasterSwordMaterial.INSTANCE, new Item.Settings().attributeModifiers(TrueMasterSwordItem.createAttributeModifiers(TrueMasterSwordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.EPIC)),"true_master_sword");
+    public static final Item GODDESS_SWORD = register(new GoddessSwordItem(),"goddess_sword");
+    public static final Item GODDESS_LONGSWORD = register(new GoddessLongswordItem(),"goddess_longsword");
+    public static final Item GODDESS_WHITE_SWORD = register(new GoddessWhiteSwordItem(),"goddess_white_sword");
+    public static final Item MASTER_SWORD = register(new MasterSwordItem(),"master_sword");
+    public static final Item TRUE_MASTER_SWORD = register(new TrueMasterSwordItem(),"true_master_sword");
     public static final Item DIGGING_MITT = register(new ShovelItem(DiggingMittMaterial.INSTANCE, new Item.Settings().attributeModifiers(ShovelItem.createAttributeModifiers(DiggingMittMaterial.INSTANCE,1,-3.0F))),"digging_mitt");
 
     // Paraglider

--- a/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessLongswordItem.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessLongswordItem.java
@@ -7,37 +7,25 @@ import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
 import net.minecraft.world.World;
 import net.nieadni.hyliacraft.item.materials.GoddessLongswordMaterial;
 import net.nieadni.hyliacraft.item.materials.GoddessSwordMaterial;
 
 public class GoddessLongswordItem extends SwordItem {
-    public GoddessLongswordItem(GoddessLongswordMaterial toolMaterial, Settings settings) {
-        super(toolMaterial, settings);
+    public GoddessLongswordItem() {
+        super(GoddessLongswordMaterial.INSTANCE, new Item.Settings().attributeModifiers(createAttributeModifiers(GoddessLongswordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.RARE));
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
-        if (!world.isClient && entity instanceof PlayerEntity player) {
-            EntityAttributeInstance reachAttribute = player.getAttributeInstance(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-            assert reachAttribute != null;
-            boolean isReachModified = reachAttribute.hasModifier(SWORD_RANGE_MODIFIER_ID);
-            if (selected && !isReachModified) {
-                reachAttribute.addTemporaryModifier(new EntityAttributeModifier(
-                        SWORD_RANGE_MODIFIER_ID,
-                        -0,    // Sets the distance between you and the entity (base=3)
-                        EntityAttributeModifier.Operation.ADD_VALUE)
-                );
-            } else if (!selected && isReachModified) {
-                reachAttribute.removeModifier(SWORD_RANGE_MODIFIER_ID);
-            }
-        }
         NbtCompound nbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT).copyNbt();
         int timer = nbt.contains(DURABILITY_KEY) ? nbt.getInt("durabilityHealTimer") : DURABILITY_TIMER;
         if (timer == 0) {

--- a/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessSwordItem.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessSwordItem.java
@@ -1,46 +1,34 @@
 package net.nieadni.hyliacraft.item.custom;
 
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.StringIdentifiable;
+import net.minecraft.util.Rarity;
 import net.minecraft.world.World;
 import net.nieadni.hyliacraft.item.materials.GoddessSwordMaterial;
 
-import java.util.Timer;
-import java.util.logging.Level;
-
 public class GoddessSwordItem extends SwordItem {
-    public GoddessSwordItem(GoddessSwordMaterial toolMaterial, Settings settings) {
-        super(toolMaterial, settings);
+    public GoddessSwordItem() {
+        super(GoddessSwordMaterial.INSTANCE, new Item.Settings().fireproof().rarity(Rarity.RARE).attributeModifiers(createAttributeModifiers(GoddessSwordMaterial.INSTANCE, 1, -2.4F).with(
+                EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE,
+                new EntityAttributeModifier(SWORD_RANGE_MODIFIER_ID, -1, EntityAttributeModifier.Operation.ADD_VALUE),
+                AttributeModifierSlot.MAINHAND
+        )));
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
-        if (!world.isClient && entity instanceof PlayerEntity player) {
-            EntityAttributeInstance reachAttribute = player.getAttributeInstance(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-            assert reachAttribute != null;
-            boolean isReachModified = reachAttribute.hasModifier(SWORD_RANGE_MODIFIER_ID);
-            if (selected && !isReachModified) {
-                reachAttribute.addTemporaryModifier(new EntityAttributeModifier(
-                        SWORD_RANGE_MODIFIER_ID,
-                        -1,    // Sets the distance between you and the entity (base=3)
-                        EntityAttributeModifier.Operation.ADD_VALUE)
-                );
-            } else if (!selected && isReachModified) {
-                reachAttribute.removeModifier(SWORD_RANGE_MODIFIER_ID);
-            }
-        }
         NbtCompound nbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT).copyNbt();
         int timer = nbt.contains(DURABILITY_KEY) ? nbt.getInt("durabilityHealTimer") : DURABILITY_TIMER;
         if (timer == 0) {

--- a/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessWhiteSwordItem.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/custom/GoddessWhiteSwordItem.java
@@ -7,37 +7,25 @@ import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
 import net.minecraft.world.World;
 import net.nieadni.hyliacraft.item.materials.GoddessSwordMaterial;
 import net.nieadni.hyliacraft.item.materials.GoddessWhiteSwordMaterial;
 
 public class GoddessWhiteSwordItem extends SwordItem {
-    public GoddessWhiteSwordItem(GoddessWhiteSwordMaterial toolMaterial, Settings settings) {
-        super(toolMaterial, settings);
+    public GoddessWhiteSwordItem() {
+        super(GoddessWhiteSwordMaterial.INSTANCE, new Item.Settings().attributeModifiers(GoddessWhiteSwordItem.createAttributeModifiers(GoddessWhiteSwordMaterial.INSTANCE,1, -2.4F)).fireproof().rarity(Rarity.RARE));
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
-        if (!world.isClient && entity instanceof PlayerEntity player) {
-            EntityAttributeInstance reachAttribute = player.getAttributeInstance(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-            assert reachAttribute != null;
-            boolean isReachModified = reachAttribute.hasModifier(SWORD_RANGE_MODIFIER_ID);
-            if (selected && !isReachModified) {
-                reachAttribute.addTemporaryModifier(new EntityAttributeModifier(
-                        SWORD_RANGE_MODIFIER_ID,
-                        -0,    // Sets the distance between you and the entity (base=3)
-                        EntityAttributeModifier.Operation.ADD_VALUE)
-                );
-            } else if (!selected && isReachModified) {
-                reachAttribute.removeModifier(SWORD_RANGE_MODIFIER_ID);
-            }
-        }
         NbtCompound nbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT).copyNbt();
         int timer = nbt.contains(DURABILITY_KEY) ? nbt.getInt("durabilityHealTimer") : DURABILITY_TIMER;
         if (timer == 0) {

--- a/src/main/java/net/nieadni/hyliacraft/item/custom/MasterSwordItem.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/custom/MasterSwordItem.java
@@ -1,43 +1,36 @@
 package net.nieadni.hyliacraft.item.custom;
 
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
 import net.minecraft.world.World;
 import net.nieadni.hyliacraft.item.materials.GoddessSwordMaterial;
 import net.nieadni.hyliacraft.item.materials.MasterSwordMaterial;
 
 public class MasterSwordItem extends SwordItem {
-    public MasterSwordItem(MasterSwordMaterial toolMaterial, Settings settings) {
-        super(toolMaterial, settings);
+    public MasterSwordItem() {
+        super(MasterSwordMaterial.INSTANCE, new Item.Settings().fireproof().rarity(Rarity.EPIC).attributeModifiers(MasterSwordItem.createAttributeModifiers(MasterSwordMaterial.INSTANCE,1, -2.4F).with(
+                EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE,
+                new EntityAttributeModifier(SWORD_RANGE_MODIFIER_ID, 1, EntityAttributeModifier.Operation.ADD_VALUE),
+                AttributeModifierSlot.MAINHAND
+        )));
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
-        if (!world.isClient && entity instanceof PlayerEntity player) {
-            EntityAttributeInstance reachAttribute = player.getAttributeInstance(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-            assert reachAttribute != null;
-            boolean isReachModified = reachAttribute.hasModifier(SWORD_RANGE_MODIFIER_ID);
-            if (selected && !isReachModified) {
-                reachAttribute.addTemporaryModifier(new EntityAttributeModifier(
-                        SWORD_RANGE_MODIFIER_ID,
-                        +1,    // Sets the distance between you and the entity (base=3)
-                        EntityAttributeModifier.Operation.ADD_VALUE)
-                );
-            } else if (!selected && isReachModified) {
-                reachAttribute.removeModifier(SWORD_RANGE_MODIFIER_ID);
-            }
-        }
         NbtCompound nbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT).copyNbt();
         int timer = nbt.contains(DURABILITY_KEY) ? nbt.getInt("durabilityHealTimer") : DURABILITY_TIMER;
         if (timer == 0) {

--- a/src/main/java/net/nieadni/hyliacraft/item/custom/TrueMasterSwordItem.java
+++ b/src/main/java/net/nieadni/hyliacraft/item/custom/TrueMasterSwordItem.java
@@ -1,43 +1,36 @@
 package net.nieadni.hyliacraft.item.custom;
 
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
 import net.minecraft.world.World;
 import net.nieadni.hyliacraft.item.materials.GoddessSwordMaterial;
 import net.nieadni.hyliacraft.item.materials.TrueMasterSwordMaterial;
 
 public class TrueMasterSwordItem extends SwordItem {
-    public TrueMasterSwordItem(TrueMasterSwordMaterial toolMaterial, Settings settings) {
-        super(toolMaterial, settings);
+    public TrueMasterSwordItem() {
+        super(TrueMasterSwordMaterial.INSTANCE, new Item.Settings().fireproof().rarity(Rarity.EPIC).attributeModifiers(TrueMasterSwordItem.createAttributeModifiers(TrueMasterSwordMaterial.INSTANCE,1, -2.4F).with(
+                EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE,
+                new EntityAttributeModifier(SWORD_RANGE_MODIFIER_ID, 2, EntityAttributeModifier.Operation.ADD_VALUE),
+                AttributeModifierSlot.MAINHAND
+        )));
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
-        if (!world.isClient && entity instanceof PlayerEntity player) {
-            EntityAttributeInstance reachAttribute = player.getAttributeInstance(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE);
-            assert reachAttribute != null;
-            boolean isReachModified = reachAttribute.hasModifier(SWORD_RANGE_MODIFIER_ID);
-            if (selected && !isReachModified) {
-                reachAttribute.addTemporaryModifier(new EntityAttributeModifier(
-                        SWORD_RANGE_MODIFIER_ID,
-                        +2,    // Sets the distance between you and the entity (base=3)
-                        EntityAttributeModifier.Operation.ADD_VALUE)
-                );
-            } else if (!selected && isReachModified) {
-                reachAttribute.removeModifier(SWORD_RANGE_MODIFIER_ID);
-            }
-        }
         NbtCompound nbt = stack.getOrDefault(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT).copyNbt();
         int timer = nbt.contains(DURABILITY_KEY) ? nbt.getInt("durabilityHealTimer") : DURABILITY_TIMER;
         if (timer == 0) {


### PR DESCRIPTION
Minecraft has a built-in system for items that modify attributes when held. This is a lot simpler than the custom approach that we previously used. It also adds the tooltip lines that tell you what attributes are modified:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/c9e780e9-d17c-4cba-ae56-f65857a160ae">

This PR changes all of the custom swords so that they use the built-in system.